### PR TITLE
perf: Tier1 パフォーマンス改善（クエリ絞り込み・O(n²)解消・コード整理）

### DIFF
--- a/src/app/(authenticated)/_components/dashboard-content.tsx
+++ b/src/app/(authenticated)/_components/dashboard-content.tsx
@@ -1,4 +1,3 @@
-import { getProfile } from "@/lib/supabase/auth";
 import { createClient } from "@/lib/supabase/server";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import Link from "next/link";
@@ -38,8 +37,7 @@ export async function DashboardContent({ opponentId }: { opponentId?: string }) 
     seriesQuery = seriesQuery.eq("opponent_id", opponentId);
   }
 
-  const [, { data: allSeriesData }, { data: players }] = await Promise.all([
-    getProfile(),
+  const [{ data: allSeriesData }, { data: players }] = await Promise.all([
     seriesQuery,
     supabase.from("players").select("id, name"),
   ]);
@@ -75,6 +73,15 @@ export async function DashboardContent({ opponentId }: { opponentId?: string }) 
 
   const winRate = totalGames > 0 ? ((totalWins / totalGames) * 100).toFixed(1) : "0";
 
+  const seriesGameSummary = new Map<string, { wins: number; draws: number; losses: number }>();
+  for (const g of allGames) {
+    const entry = seriesGameSummary.get(g.series_id) ?? { wins: 0, draws: 0, losses: 0 };
+    if (g.result === "win") entry.wins++;
+    else if (g.result === "draw") entry.draws++;
+    else entry.losses++;
+    seriesGameSummary.set(g.series_id, entry);
+  }
+
   const modeStats = (["hardpoint", "snd", "overload"] as const).map((mode) => {
     const mc = modeCounts[mode];
     const rate = mc.total > 0 ? ((mc.wins / mc.total) * 100).toFixed(1) : "0";
@@ -100,8 +107,15 @@ export async function DashboardContent({ opponentId }: { opponentId?: string }) 
     };
   }
 
+  const statsByPlayerId = new Map<string, GameStat[]>();
+  for (const s of filteredStats) {
+    const arr = statsByPlayerId.get(s.player_id) ?? [];
+    arr.push(s);
+    statsByPlayerId.set(s.player_id, arr);
+  }
+
   const playerKDData: PlayerKDData[] = allPlayers.map((player) => {
-    const pStats = filteredStats.filter((s) => s.player_id === player.id);
+    const pStats = statsByPlayerId.get(player.id) ?? [];
     let totalKills = 0, totalDeaths = 0, totalDamage = 0;
     const modes: Record<string, ModeAcc> = { hardpoint: emptyModeAcc(), snd: emptyModeAcc(), overload: emptyModeAcc() };
     for (const s of pStats) {
@@ -134,9 +148,7 @@ export async function DashboardContent({ opponentId }: { opponentId?: string }) 
     };
   });
 
-  const recentSeries = opponentId
-    ? allSeries.filter((s) => s.opponent_id === opponentId).slice(0, 5)
-    : allSeries.slice(0, 5);
+  const recentSeries = allSeries.slice(0, 5);
 
   return (
     <>
@@ -200,10 +212,7 @@ export async function DashboardContent({ opponentId }: { opponentId?: string }) 
             {/* Mobile card layout */}
             <div className="space-y-2 sm:hidden">
               {recentSeries.map((s) => {
-                const sGames = allGames.filter((g) => g.series_id === s.id);
-                const w = sGames.filter((g) => g.result === "win").length;
-                const d = sGames.filter((g) => g.result === "draw").length;
-                const l = sGames.length - w - d;
+                const { wins: w, draws: d, losses: l } = seriesGameSummary.get(s.id) ?? { wins: 0, draws: 0, losses: 0 };
                 const isWin = w > l;
                 const isLoss = l > w;
                 return (
@@ -254,10 +263,7 @@ export async function DashboardContent({ opponentId }: { opponentId?: string }) 
                 </thead>
                 <tbody>
                   {recentSeries.map((s) => {
-                    const sGames = allGames.filter((g) => g.series_id === s.id);
-                    const w = sGames.filter((g) => g.result === "win").length;
-                    const d = sGames.filter((g) => g.result === "draw").length;
-                    const l = sGames.length - w - d;
+                    const { wins: w, draws: d, losses: l } = seriesGameSummary.get(s.id) ?? { wins: 0, draws: 0, losses: 0 };
                     const isWin = w > l;
                     const isLoss = l > w;
                     return (

--- a/src/app/(authenticated)/matches/[id]/_components/series-detail-content.tsx
+++ b/src/app/(authenticated)/matches/[id]/_components/series-detail-content.tsx
@@ -35,17 +35,18 @@ export async function SeriesDetailContent({ id }: { id: string }) {
   type ModeAcc = { kills: number; deaths: number; damage: number; count: number; hillTime: number; plants: number; defuses: number; firstBloods: number; firstDeaths: number; goals: number };
   const emptyModeAcc = (): ModeAcc => ({ kills: 0, deaths: 0, damage: 0, count: 0, hillTime: 0, plants: 0, defuses: 0, firstBloods: 0, firstDeaths: 0, goals: 0 });
 
-  const playerMap = new Map<string, { id: string; name: string; kills: number; deaths: number; damage: number; modes: Record<string, ModeAcc> }>();
+  const playerMap = new Map<string, { id: string; name: string; kills: number; deaths: number; damage: number; count: number; modes: Record<string, ModeAcc> }>();
   for (const stat of allStats) {
     const pid = stat.player_id;
     const mode = gameIdToMode.get(stat.game_id) ?? "";
     if (!playerMap.has(pid)) {
-      playerMap.set(pid, { id: pid, name: stat.players?.name ?? "-", kills: 0, deaths: 0, damage: 0, modes: { hardpoint: emptyModeAcc(), snd: emptyModeAcc(), overload: emptyModeAcc() } });
+      playerMap.set(pid, { id: pid, name: stat.players?.name ?? "-", kills: 0, deaths: 0, damage: 0, count: 0, modes: { hardpoint: emptyModeAcc(), snd: emptyModeAcc(), overload: emptyModeAcc() } });
     }
     const p = playerMap.get(pid)!;
     p.kills += stat.kills;
     p.deaths += stat.deaths;
     p.damage += stat.damage;
+    p.count++;
     const m = p.modes[mode];
     if (m) {
       m.kills += stat.kills;
@@ -77,17 +78,14 @@ export async function SeriesDetailContent({ id }: { id: string }) {
     };
   }
 
-  const playerKDData: PlayerKDData[] = [...playerMap.values()].map((p) => {
-    const c = allStats.filter((s) => s.player_id === p.id).length;
-    return {
+  const playerKDData: PlayerKDData[] = [...playerMap.values()].map((p) => ({
     id: p.id,
     name: p.name,
-    overall: { avgKills: avg(p.kills, c), avgDeaths: avg(p.deaths, c), avgDamage: avg(p.damage, c), count: c, kd: calcKD(p.kills, p.deaths), avgHillTime: null, avgPlants: null, avgDefuses: null, avgFirstBloods: null, avgFirstDeaths: null, avgGoals: null },
+    overall: { avgKills: avg(p.kills, p.count), avgDeaths: avg(p.deaths, p.count), avgDamage: avg(p.damage, p.count), count: p.count, kd: calcKD(p.kills, p.deaths), avgHillTime: null, avgPlants: null, avgDefuses: null, avgFirstBloods: null, avgFirstDeaths: null, avgGoals: null },
     hardpoint: toModeStats(p.modes.hardpoint),
     snd: toModeStats(p.modes.snd),
     overload: toModeStats(p.modes.overload),
-  };
-  });
+  }));
 
   return (
     <>

--- a/src/app/(authenticated)/matches/page.tsx
+++ b/src/app/(authenticated)/matches/page.tsx
@@ -11,7 +11,7 @@ export default async function MatchesPage() {
     getProfile(),
     supabase
       .from("series")
-      .select("*, opponents(*), games(result)")
+      .select("*, opponents(id, name), games(result)")
       .order("series_date", { ascending: false })
       .limit(50),
     supabase.from("opponents").select("id, name").order("name"),

--- a/src/app/(authenticated)/opponents/[id]/_components/opponent-detail-content.tsx
+++ b/src/app/(authenticated)/opponents/[id]/_components/opponent-detail-content.tsx
@@ -1,4 +1,3 @@
-import { getProfile } from "@/lib/supabase/auth";
 import { createClient } from "@/lib/supabase/server";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { notFound } from "next/navigation";
@@ -16,8 +15,7 @@ const resultClass: Record<string, string> = {
 export async function OpponentDetailContent({ id }: { id: string }) {
   const supabase = await createClient();
 
-  const [, { data: opponent }, { data: seriesData }] = await Promise.all([
-    getProfile(),
+  const [{ data: opponent }, { data: seriesData }] = await Promise.all([
     supabase.from("opponents").select("*").eq("id", id).single(),
     supabase
       .from("series")

--- a/src/app/(authenticated)/opponents/page.tsx
+++ b/src/app/(authenticated)/opponents/page.tsx
@@ -8,7 +8,7 @@ export default async function OpponentsPage() {
 
   const [{ profile }, { data: opponents }, { data: series }] = await Promise.all([
     getProfile(),
-    supabase.from("opponents").select("id, name, opponent_players(*)").order("name"),
+    supabase.from("opponents").select("id, name, opponent_players(id, name, is_default, created_at, opponent_id, team_id)").order("name"),
     supabase.from("series").select("opponent_id, games(mode, result)").limit(200),
   ]);
 

--- a/src/app/(authenticated)/players/[id]/_components/player-detail-content.tsx
+++ b/src/app/(authenticated)/players/[id]/_components/player-detail-content.tsx
@@ -1,13 +1,8 @@
-import { getProfile } from "@/lib/supabase/auth";
 import { createClient } from "@/lib/supabase/server";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { notFound } from "next/navigation";
 import type { GameStat, GameMode, MatchResult } from "@/lib/types";
-
-function calcKD(kills: number, deaths: number) {
-  if (deaths === 0) return kills.toFixed(2);
-  return (kills / deaths).toFixed(2);
-}
+import { calcKD } from "@/lib/utils";
 
 function avg(arr: number[]) {
   if (arr.length === 0) return "0";
@@ -19,8 +14,7 @@ const modeLabel: Record<string, string> = { hardpoint: "Hardpoint", snd: "S&D", 
 export async function PlayerDetailContent({ id }: { id: string }) {
   const supabase = await createClient();
 
-  const [, { data: player }, { data: stats }] = await Promise.all([
-    getProfile(),
+  const [{ data: player }, { data: stats }] = await Promise.all([
     supabase.from("players").select("*").eq("id", id).single(),
     supabase.from("game_stats").select("*, games(mode, result)").eq("player_id", id).limit(500),
   ]);


### PR DESCRIPTION
- opponents(*) → opponents(id, name) に絞る（matches/page.tsx）
- opponent_players(*) → 必要6カラムに絞る（opponents/page.tsx）
- ダッシュボードの冗長フィルタ削除（opponentId 指定時の二重 filter）
- recentSeries レンダリングの O(n²) → Map 事前集計に変換（dashboard-content.tsx）
- プレイヤー別スタッツ集計の O(n²) → statsByPlayerId Map に変換（dashboard-content.tsx）
- series-detail-content.tsx: playerMap に count を持たせ allStats.filter() 二重集計を削除
- 未使用 getProfile() 呼び出しを3ファイルから削除
- calcKD の重複ローカル定義を削除し @/lib/utils からインポートに統一

https://claude.ai/code/session_01NQZLJ3uadSuZHuJhDZAz5p